### PR TITLE
setting/#12: Theme.kt에 Typography 추가

### DIFF
--- a/app/src/main/java/org/sopt/starbanking/ui/theme/Theme.kt
+++ b/app/src/main/java/org/sopt/starbanking/ui/theme/Theme.kt
@@ -16,15 +16,20 @@ object StarBankingTheme {
         @Composable
         @ReadOnlyComposable
         get() = LocalStarBankingColorsProvider.current
+
+    val typography: kbStarBankingTypography
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalkbStarBankingTypographyProvider.current
 }
 
 @Composable
 fun StarBankingTheme(
     content: @Composable () -> Unit
 ) {
-    val colors = defaultStarBankingColors
     CompositionLocalProvider(
-        LocalStarBankingColorsProvider provides colors
+        LocalStarBankingColorsProvider provides defaultStarBankingColors,
+        LocalkbStarBankingTypographyProvider provides defaultkbStarBankingTypography
     ) {
         MaterialTheme(
             colorScheme = LightColorScheme,


### PR DESCRIPTION
## ✨ ISSUE
- closed #12

## ❗ WORK DESCRIPTION
- `kbStarBankingTypography`에 정의한 폰트를 StarBankingTheme에서 사용 가능하도록 수정했습니다.

## 📸 SCREENSHOT


## 💻 주요 코드
- 폰트 사용 시 `StarBankingTheme.typography` 사용하시면 됩니다.

## 📢 TO REVIEWERS
- 제가 컬러 세팅할 때 Theme.kt도 수정해버려서 폰트도 StarBankingTheme에서 사용하려면 수정해야 할 것 같아 진행했습니다..!! 한 번 확인해주세용,,
