### PR TITLE
feature/#18 계좌 상세 스크린 UI 구현

### DIFF
--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/AccountDetailScreen.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/AccountDetailScreen.kt
@@ -16,9 +16,11 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.starbanking.R
+import org.sopt.starbanking.core.components.CustomHorizontalDivider
 import org.sopt.starbanking.core.components.CustomTopBar
 import org.sopt.starbanking.core.components.TopBarAction
 import org.sopt.starbanking.core.components.TopBarState
+import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailDivider
 import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailInfoWrapper
 import org.sopt.starbanking.ui.theme.defaultStarBankingColors
 
@@ -67,6 +69,8 @@ private fun AccountDetailScreen(
                 .padding(horizontal = 23.dp)
         ) {
             AccountDetailInfoWrapper()
+            Spacer(Modifier.height(18.dp))
+            AccountDetailDivider()
         }
     }
 }

--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/AccountDetailScreen.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/AccountDetailScreen.kt
@@ -1,0 +1,54 @@
+package org.sopt.starbanking.presentation.accountDetail
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import org.sopt.starbanking.R
+import org.sopt.starbanking.core.components.CustomTopBar
+import org.sopt.starbanking.core.components.TopBarAction
+import org.sopt.starbanking.core.components.TopBarState
+
+@Composable
+fun AccountDetailRoute(
+    padding: PaddingValues,
+    navigateToTransactionHistory: () -> Unit,
+    navigateToAccountInterest: () -> Unit,
+) {
+    AccountDetailScreen(
+        padding = padding,
+        navigateToTransactionHistory,
+        navigateToAccountInterest
+    )
+}
+
+@Composable
+private fun AccountDetailScreen(
+    padding: PaddingValues,
+    navigateToTransactionHistory: () -> Unit,
+    navigateToAccountInterest: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val topBarState = TopBarState(
+        title = stringResource(R.string.TopBar_View3_title),
+        showNavigationIcon = false,
+        actions = listOf(
+            TopBarAction(
+                icon = ImageVector.vectorResource(R.drawable.ic_close),
+                contentDescription = stringResource(R.string.ic_close_description),
+                onClick = navigateToTransactionHistory
+            )
+        )
+    )
+    Column(
+        modifier = modifier.padding(padding)
+    ) {
+        CustomTopBar(
+            topBarState
+        )
+    }
+}

--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/AccountDetailScreen.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/AccountDetailScreen.kt
@@ -15,17 +15,20 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import org.sopt.starbanking.R
 import org.sopt.starbanking.core.components.CustomHorizontalDivider
 import org.sopt.starbanking.core.components.CustomTopBar
 import org.sopt.starbanking.core.components.TopBarAction
 import org.sopt.starbanking.core.components.TopBarState
 import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailDivider
-import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailInfoWrapper
+import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailMainInfo
 import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailTitleCard
-import org.sopt.starbanking.presentation.accountDetail.type.AccountDetailCardType.BOLD_WITH_ICON
 import org.sopt.starbanking.presentation.accountDetail.type.AccountDetailCardType.BOLD
+import org.sopt.starbanking.presentation.accountDetail.type.AccountDetailCardType.BOLD_WITH_ICON
 import org.sopt.starbanking.presentation.accountDetail.type.AccountDetailCardType.LIGHT_WITH_ICON
+import org.sopt.starbanking.presentation.accountDetail.viewmodel.AccountDetailUiModel
+import org.sopt.starbanking.presentation.accountDetail.viewmodel.AccountDetailViewModel
 import org.sopt.starbanking.ui.theme.defaultStarBankingColors
 
 @Composable
@@ -33,11 +36,14 @@ fun AccountDetailRoute(
     padding: PaddingValues,
     navigateToTransactionHistory: () -> Unit,
     navigateToAccountInterest: () -> Unit,
+    viewModel: AccountDetailViewModel = hiltViewModel()
 ) {
+    val accountInfo: AccountDetailUiModel = viewModel.uiState.value
     AccountDetailScreen(
         padding = padding,
         navigateToTransactionHistory,
-        navigateToAccountInterest
+        navigateToAccountInterest,
+        accountInfo,
     )
 }
 
@@ -46,6 +52,7 @@ private fun AccountDetailScreen(
     padding: PaddingValues,
     navigateToTransactionHistory: () -> Unit,
     navigateToAccountInterest: () -> Unit,
+    accountInfo: AccountDetailUiModel,
     modifier: Modifier = Modifier
 ) {
     val topBarState = TopBarState(
@@ -72,7 +79,9 @@ private fun AccountDetailScreen(
                 .fillMaxWidth()
                 .padding(horizontal = 23.dp)
         ) {
-            AccountDetailInfoWrapper()
+            AccountDetailMainInfo(
+                accountInfo
+            )
             Spacer(Modifier.height(18.dp))
             AccountDetailDivider()
             Spacer(Modifier.height(24.dp))
@@ -130,5 +139,11 @@ private fun PreviewThisScreen() {
         padding = PaddingValues(10.dp),
         navigateToAccountInterest = {},
         navigateToTransactionHistory = {},
+        accountInfo = AccountDetailUiModel(
+            depositCount = 1,
+            accountState = "정상",
+            lastTransaction = "2025.05.01",
+            contractPeriod = 6
+        )
     )
 }

--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/AccountDetailScreen.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/AccountDetailScreen.kt
@@ -22,6 +22,7 @@ import org.sopt.starbanking.core.components.TopBarAction
 import org.sopt.starbanking.core.components.TopBarState
 import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailDivider
 import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailInfoWrapper
+import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailTitleItem
 import org.sopt.starbanking.ui.theme.defaultStarBankingColors
 
 @Composable
@@ -71,7 +72,19 @@ private fun AccountDetailScreen(
             AccountDetailInfoWrapper()
             Spacer(Modifier.height(18.dp))
             AccountDetailDivider()
+            Spacer(Modifier.height(24.dp))
+            AccountDetailTitleItem(
+                title = "과세정보",
+                verticalPadding = 20,
+            )
+            AccountDetailDivider()
+            AccountDetailTitleItem(
+                title = "대출정보 목록",
+                verticalPadding = 20,
+            )
+            Spacer(Modifier.height(30.dp))
         }
+        CustomHorizontalDivider()
     }
 }
 

--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/AccountDetailScreen.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/AccountDetailScreen.kt
@@ -22,7 +22,10 @@ import org.sopt.starbanking.core.components.TopBarAction
 import org.sopt.starbanking.core.components.TopBarState
 import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailDivider
 import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailInfoWrapper
-import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailTitleItem
+import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailTitleCard
+import org.sopt.starbanking.presentation.accountDetail.type.AccountDetailCardType.BOLD_WITH_ICON
+import org.sopt.starbanking.presentation.accountDetail.type.AccountDetailCardType.BOLD
+import org.sopt.starbanking.presentation.accountDetail.type.AccountDetailCardType.LIGHT_WITH_ICON
 import org.sopt.starbanking.ui.theme.defaultStarBankingColors
 
 @Composable
@@ -73,18 +76,50 @@ private fun AccountDetailScreen(
             Spacer(Modifier.height(18.dp))
             AccountDetailDivider()
             Spacer(Modifier.height(24.dp))
-            AccountDetailTitleItem(
+            AccountDetailTitleCard(
                 title = "과세정보",
-                verticalPadding = 20,
+                cardType = BOLD_WITH_ICON,
             )
             AccountDetailDivider()
-            AccountDetailTitleItem(
+            AccountDetailTitleCard(
                 title = "대출정보 목록",
-                verticalPadding = 20,
+                cardType = BOLD_WITH_ICON,
             )
+            AccountDetailDivider()
             Spacer(Modifier.height(30.dp))
         }
         CustomHorizontalDivider()
+        Spacer(Modifier.height(30.dp))
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 23.dp)
+        ) {
+            AccountDetailTitleCard(
+                title = "관리하기",
+                cardType = BOLD,
+            )
+            AccountDetailTitleCard(
+                title = "상품안내",
+                cardType = LIGHT_WITH_ICON,
+            )
+            AccountDetailDivider()
+            AccountDetailTitleCard(
+                title = "계좌이율 보기",
+                cardType = LIGHT_WITH_ICON,
+                onClick = navigateToAccountInterest
+            )
+            AccountDetailDivider()
+            AccountDetailTitleCard(
+                title = "자동이체 등록",
+                cardType = LIGHT_WITH_ICON,
+            )
+            AccountDetailDivider()
+            AccountDetailTitleCard(
+                title = "상품만기 알림서비스 신청/해지",
+                cardType = LIGHT_WITH_ICON,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/AccountDetailScreen.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/AccountDetailScreen.kt
@@ -1,17 +1,26 @@
 package org.sopt.starbanking.presentation.accountDetail
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import org.sopt.starbanking.R
 import org.sopt.starbanking.core.components.CustomTopBar
 import org.sopt.starbanking.core.components.TopBarAction
 import org.sopt.starbanking.core.components.TopBarState
+import org.sopt.starbanking.presentation.accountDetail.components.AccountDetailInfoWrapper
+import org.sopt.starbanking.ui.theme.defaultStarBankingColors
 
 @Composable
 fun AccountDetailRoute(
@@ -45,10 +54,29 @@ private fun AccountDetailScreen(
         )
     )
     Column(
-        modifier = modifier.padding(padding)
+        modifier = modifier
+            .fillMaxSize()
+            .padding(padding)
+            .background(defaultStarBankingColors.white)
     ) {
-        CustomTopBar(
-            topBarState
-        )
+        CustomTopBar(topBarState)
+        Spacer(Modifier.height(18.dp))
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 23.dp)
+        ) {
+            AccountDetailInfoWrapper()
+        }
     }
+}
+
+@Preview
+@Composable
+private fun PreviewThisScreen() {
+    AccountDetailScreen(
+        padding = PaddingValues(10.dp),
+        navigateToAccountInterest = {},
+        navigateToTransactionHistory = {},
+    )
 }

--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/components/AccountDetailDivider.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/components/AccountDetailDivider.kt
@@ -1,0 +1,20 @@
+package org.sopt.starbanking.presentation.accountDetail.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.sopt.starbanking.ui.theme.defaultStarBankingColors
+
+@Composable
+fun AccountDetailDivider(
+    modifier: Modifier = Modifier
+) {
+    Box(modifier = modifier
+        .fillMaxWidth()
+        .height(1.dp)
+        .background(defaultStarBankingColors.gray1))
+}

--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/components/AccountDetailInfoWrapper.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/components/AccountDetailInfoWrapper.kt
@@ -1,0 +1,85 @@
+package org.sopt.starbanking.presentation.accountDetail.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.starbanking.ui.theme.defaultkbStarBankingTypography
+
+@Composable
+fun AccountDetailInfoWrapper(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Row(
+            modifier = modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "납입회차",
+                style = defaultkbStarBankingTypography.body1_L
+            )
+            Text(
+                text = "1",
+                style = defaultkbStarBankingTypography.body1_L
+            )
+        }
+        Row(
+            modifier = modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "납입회차",
+                style = defaultkbStarBankingTypography.body1_L
+            )
+            Text(
+                text = "1",
+                style = defaultkbStarBankingTypography.body1_L
+            )
+        }
+        Row(
+            modifier = modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "납입회차",
+                style = defaultkbStarBankingTypography.body1_L
+            )
+            Text(
+                text = "1",
+                style = defaultkbStarBankingTypography.body1_L
+            )
+        }
+        Row(
+            modifier = modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "납입회차",
+                style = defaultkbStarBankingTypography.body1_L
+            )
+            Text(
+                text = "1",
+                style = defaultkbStarBankingTypography.body1_L
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewThis() {
+    AccountDetailInfoWrapper()
+}

--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/components/AccountDetailMainInfo.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/components/AccountDetailMainInfo.kt
@@ -10,10 +10,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import org.sopt.starbanking.presentation.accountDetail.viewmodel.AccountDetailUiModel
 import org.sopt.starbanking.ui.theme.defaultkbStarBankingTypography
 
 @Composable
-fun AccountDetailInfoWrapper(
+fun AccountDetailMainInfo(
+    accountInfo: AccountDetailUiModel,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -29,7 +31,7 @@ fun AccountDetailInfoWrapper(
                 style = defaultkbStarBankingTypography.body1_L
             )
             Text(
-                text = "1",
+                text = accountInfo.depositCount.toString(),
                 style = defaultkbStarBankingTypography.body1_L
             )
         }
@@ -39,25 +41,11 @@ fun AccountDetailInfoWrapper(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "납입회차",
+                text = "계좌상태",
                 style = defaultkbStarBankingTypography.body1_L
             )
             Text(
-                text = "1",
-                style = defaultkbStarBankingTypography.body1_L
-            )
-        }
-        Row(
-            modifier = modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = "납입회차",
-                style = defaultkbStarBankingTypography.body1_L
-            )
-            Text(
-                text = "1",
+                text = accountInfo.accountState,
                 style = defaultkbStarBankingTypography.body1_L
             )
         }
@@ -67,11 +55,25 @@ fun AccountDetailInfoWrapper(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "납입회차",
+                text = "최종거래일",
                 style = defaultkbStarBankingTypography.body1_L
             )
             Text(
-                text = "1",
+                text = accountInfo.lastTransaction,
+                style = defaultkbStarBankingTypography.body1_L
+            )
+        }
+        Row(
+            modifier = modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "계약기간",
+                style = defaultkbStarBankingTypography.body1_L
+            )
+            Text(
+                text = accountInfo.contractPeriod.toString(),
                 style = defaultkbStarBankingTypography.body1_L
             )
         }
@@ -81,5 +83,12 @@ fun AccountDetailInfoWrapper(
 @Preview
 @Composable
 private fun PreviewThis() {
-    AccountDetailInfoWrapper()
+    AccountDetailMainInfo(
+        AccountDetailUiModel(
+            depositCount = 1,
+            accountState = "정상",
+            lastTransaction = "2025.05.01",
+            contractPeriod = 6
+        )
+    )
 }

--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/components/AccountDetailTitleCard.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/components/AccountDetailTitleCard.kt
@@ -12,30 +12,31 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
-import org.sopt.starbanking.R
-import org.sopt.starbanking.ui.theme.defaultkbStarBankingTypography
-import org.sopt.starbanking.ui.theme.kbStarBankingFontBold
+import org.sopt.starbanking.presentation.accountDetail.type.AccountDetailCardType
 
 @Composable
-fun AccountDetailTitleItem(
+fun AccountDetailTitleCard(
     title: String,
-    verticalPadding: Int,
+    cardType: AccountDetailCardType,
     modifier: Modifier = Modifier,
+    onClick: () -> Unit = {}
 ) {
     Row(
         modifier = modifier
-            .fillMaxWidth()
-            .padding(vertical = verticalPadding.dp),
+            .padding(vertical = cardType.verticalPadding.dp)
+            .fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Text(
             text = title,
-            style = defaultkbStarBankingTypography.title2_B
+            style = cardType.textStyle
         )
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_down),
-            contentDescription = "test",
-            tint = Color.Unspecified,
-        )
+        cardType.iconResId?.let { resId ->
+            Icon(
+                imageVector = ImageVector.vectorResource(resId),
+                contentDescription = cardType.iconDescription,
+                tint = Color.Unspecified,
+            )
+        }
     }
 }

--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/components/AccountDetailTitleItem.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/components/AccountDetailTitleItem.kt
@@ -1,0 +1,41 @@
+package org.sopt.starbanking.presentation.accountDetail.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import org.sopt.starbanking.R
+import org.sopt.starbanking.ui.theme.defaultkbStarBankingTypography
+import org.sopt.starbanking.ui.theme.kbStarBankingFontBold
+
+@Composable
+fun AccountDetailTitleItem(
+    title: String,
+    verticalPadding: Int,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = verticalPadding.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = title,
+            style = defaultkbStarBankingTypography.title2_B
+        )
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_down),
+            contentDescription = "test",
+            tint = Color.Unspecified,
+        )
+    }
+}

--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/navigation/AccountDetailNavigation.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/navigation/AccountDetailNavigation.kt
@@ -1,0 +1,30 @@
+package org.sopt.starbanking.presentation.accountDetail.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import org.sopt.starbanking.core.navigation.Route
+import org.sopt.starbanking.presentation.accountDetail.AccountDetailRoute
+
+fun NavController.navigateToTransactionHistory() {
+    navigate(Route.TransactionHistory)
+}
+
+fun NavController.navigateToAccountInterest() {
+    navigate(Route.AccountInterest)
+}
+
+fun NavGraphBuilder.accountDetailGraph(
+    navigateToTransactionHistory: () -> Unit,
+    navigateToAccountInterest: () -> Unit,
+    padding: PaddingValues
+) {
+    composable<Route.AccountDetail> {
+        AccountDetailRoute(
+            padding = padding,
+            navigateToTransactionHistory,
+            navigateToAccountInterest,
+        )
+    }
+}

--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/type/AccountDetailIconType.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/type/AccountDetailIconType.kt
@@ -1,0 +1,32 @@
+package org.sopt.starbanking.presentation.accountDetail.type
+
+import androidx.annotation.StringRes
+import androidx.compose.ui.text.TextStyle
+import org.sopt.starbanking.R
+import org.sopt.starbanking.ui.theme.defaultkbStarBankingTypography
+
+enum class AccountDetailCardType(
+    @StringRes val iconResId: Int?,
+    val textStyle: TextStyle,
+    val iconDescription: String,
+    val verticalPadding: Int
+) {
+    BOLD_WITH_ICON(
+        iconResId = R.drawable.ic_arrow_down,
+        textStyle = defaultkbStarBankingTypography.title2_B,
+        iconDescription = "down arrow",
+        verticalPadding = 20
+    ),
+    BOLD(
+        iconResId = null,
+        textStyle = defaultkbStarBankingTypography.title2_B,
+        iconDescription = "",
+        verticalPadding = 7
+    ),
+    LIGHT_WITH_ICON(
+        iconResId = R.drawable.ic_arrow_right,
+        textStyle = defaultkbStarBankingTypography.body1_L,
+        iconDescription = "right arrow",
+        verticalPadding = 18
+    )
+}

--- a/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/viewmodel/AccountDetailViewModel.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/accountDetail/viewmodel/AccountDetailViewModel.kt
@@ -1,0 +1,37 @@
+package org.sopt.starbanking.presentation.accountDetail.viewmodel
+
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+data class AccountDetailUiModel(
+    val depositCount: Int,
+    val accountState: String,
+    val lastTransaction: String,
+    val contractPeriod: Int
+)
+
+
+@HiltViewModel
+class AccountDetailViewModel @Inject constructor() : ViewModel() {
+    private val _uiState = mutableStateOf<AccountDetailUiModel>(
+        AccountDetailUiModel(
+            depositCount = 1,
+            accountState = "정상",
+            lastTransaction = "2025.05.01",
+            contractPeriod = 6
+        )
+    )
+    val uiState: State<AccountDetailUiModel> = _uiState
+
+    init {
+        _uiState.value = AccountDetailUiModel(
+            depositCount = 1,
+            accountState = "정상",
+            lastTransaction = "2025.05.01",
+            contractPeriod = 6
+        )
+    }
+}

--- a/app/src/main/java/org/sopt/starbanking/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/main/MainNavHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
+import org.sopt.starbanking.presentation.accountDetail.navigation.accountDetailGraph
 import org.sopt.starbanking.presentation.home.navigation.homeNavGraph
 
 @Composable
@@ -22,6 +23,11 @@ fun MainNavHost(
             startDestination = navigator.startDestination
         ) {
             homeNavGraph(padding = padding)
+            accountDetailGraph(
+                padding = padding,
+                navigateToTransactionHistory = navigator::navigateToTransactionHistory,
+                navigateToAccountInterest = navigator::navigateToAccountInterest
+            )
         }
     }
 }

--- a/app/src/main/java/org/sopt/starbanking/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/org/sopt/starbanking/presentation/main/MainNavigator.kt
@@ -10,6 +10,8 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import org.sopt.starbanking.core.navigation.Route
+import org.sopt.starbanking.presentation.accountDetail.navigation.navigateToAccountInterest
+import org.sopt.starbanking.presentation.accountDetail.navigation.navigateToTransactionHistory
 import org.sopt.starbanking.presentation.home.navigation.navigateToHome
 
 
@@ -19,7 +21,7 @@ class MainNavigator(
     private val currentDestination: NavDestination?
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
-    val startDestination = Route.Home
+    val startDestination = Route.AccountDetail
 
     fun navigateToHome(navOptions: NavOptions? = null) {
         navController.navigateToHome(
@@ -30,6 +32,14 @@ class MainNavigator(
                 launchSingleTop = true
             }
         )
+    }
+
+    fun navigateToTransactionHistory() {
+        navController.navigateToTransactionHistory()
+    }
+
+    fun navigateToAccountInterest() {
+        navController.navigateToAccountInterest()
     }
 }
 

--- a/app/src/main/res/drawable/ic_arrow_down.xml
+++ b/app/src/main/res/drawable/ic_arrow_down.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M0,24l0,-24l24,-0l0,24z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M18,9.615L12,15L6,9.615L6.686,9L12,13.769L17.314,9L18,9.615Z"
+      android:strokeAlpha="0.5"
+      android:fillColor="#000000"
+      android:fillAlpha="0.5"/>
+</vector>

--- a/app/src/main/res/drawable/ic_arrow_right.xml
+++ b/app/src/main/res/drawable/ic_arrow_right.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M24,0l-0,24l-24,0l-0,-24z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M9.615,6L15,12L9.615,18L9,17.314L13.769,12L9,6.686L9.615,6Z"
+      android:strokeAlpha="0.5"
+      android:fillColor="#000000"
+      android:fillAlpha="0.5"/>
+</vector>


### PR DESCRIPTION
## ✨ ISSUE
- closed #18 

## ❗ WORK DESCRIPTION
- 계좌 상세 스크린(피그마 상 뷰3) UI를 구현했습니다.

## 📸 SCREENSHOT
<img src="https://github.com/user-attachments/assets/d6bca41a-2e5e-43e2-85fd-cd4c77074058" width="300" />


## 💻 주요 코드

@nhyeonii `MainNavigator`에서 startDestination 구현하신 뷰에 맞춰서 실행하면 Build도 확인 가능합니다!

```kotlin
val startDestination = Route.AccountDetail
```
- 아직 서버통신 전이라 뷰모델 우선 하드코딩 상태에용 ㅠ

## 📢 TO REVIEWERS
- API 연결까지 후딱 끝내보아요!
